### PR TITLE
Set and edit status of booking

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -26,18 +26,18 @@ class BookingsController < ApplicationController
   end
 
   def update
-    # @booking = Booking.find(params[:id])
-    # @booking.update(booking_params)
-    # if @booking.save!
-    #   redirect_to equipment_path(@equipment)
-    # else
-    #   render :new
-    # end
+    @booking = Booking.find(params[:id])
+    @booking.update(booking_params)
+    if @booking.save!
+      redirect_to booking_path(@booking)
+    else
+      render :new
+    end
   end
 
   private
 
   def booking_params
-    params.require(:booking).permit(:start_date, :end_date)
+    params.require(:booking).permit(:start_date, :end_date, :status)
   end
 end

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -4,6 +4,7 @@
   <% @bookings_tocheck.each do |booking|  %>
   <li><%= booking.start_date %> || <%= booking.end_date %> || <%= booking.status%></li>
   <h3><%=link_to booking.equipment.name, booking_path(booking)%></h3>
+  <%= link_to_if(booking.status == "Pending", "Accept booking", booking_path(booking, :booking => { status: "Accepted" }), :method => :put, :confirm => "Sure?", class: "btn btn-success"){} %> <%= link_to_if(booking.status == "Pending","Decline booking", booking_path(booking, :booking => { status: "Declined" }), :method => :put, :confirm => "Sure?", class: "btn btn-danger"){} %>
   <% end %>
 </ol>
 

--- a/db/migrate/20201117163924_set_status_default.rb
+++ b/db/migrate/20201117163924_set_status_default.rb
@@ -1,0 +1,5 @@
+class SetStatusDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column :bookings, :status, :string, default: "Pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_162307) do
+ActiveRecord::Schema.define(version: 2020_11_17_163924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_162307) do
   create_table "bookings", force: :cascade do |t|
     t.date "start_date"
     t.date "end_date"
-    t.string "status"
+    t.string "status", default: "Pending"
     t.bigint "user_id", null: false
     t.bigint "equipment_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
coded the status feature of the bookings
1) the status is by default set to "Pending" in the bookings table
2) a renter has the ability to accept or decline an offer in their bookings page
3) once accepted or declined the rentee will have their status change too and the renter will not be able to change the status again