### PR TITLE
add delete equipment feature

### DIFF
--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -14,12 +14,12 @@ class EquipmentController < ApplicationController
 
   def create
     @equipment = Equipment.new(equipment_params)
-      @equipment.user = current_user
-      if @equipment.save!
-        redirect_to @equipment, notice: "Equipment was succesfully created."
-      else
-        render :new
-      end
+    @equipment.user = current_user
+    if @equipment.save!
+      redirect_to @equipment, notice: "Equipment was succesfully created."
+    else
+      render :new
+    end
   end
 
   def edit
@@ -36,12 +36,16 @@ class EquipmentController < ApplicationController
     end
   end
 
+  def destroy
+    @equipment = Equipment.find(params[:id])
+    @equipment.destroy
+    redirect_to equipment_index_path
+  end
+
   private
 
   def equipment_params
     params.require(:equipment).permit(:name, :description, :category, :price, :location)
   end
 end
-
-
 

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,6 +1,6 @@
 class Equipment < ApplicationRecord
   belongs_to :user
-  has_many :bookings
+  has_many :bookings, dependent: :destroy
 
   validates :name, :description, :category, :location, :price, presence: true
 end

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -6,4 +6,5 @@
 
 <%= link_to "Return", equipment_index_path %>
 <%= link_to "Edit equipment", edit_equipment_path(@equipment)  %>
+<%= link_to "Delete equipment", equipment_path(@equipment), method: :delete, data: { confirm: "Are you sure?"}%>
 <%= link_to "Book equipment", new_equipment_booking_path(@equipment)  %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,7 +16,7 @@
 
 
   <div class="navbar-login dropdown">
-    <%= link_to "equipment", root_path %>
+    <%= link_to "equipment", equipment_index_path %>
     <%= link_to "contact", root_path(anchor: 'footer') %>
     <button>
       <div class="avatar dropdown-toggle" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
as above.

users can delete a piece of equipment from the show page -> as a result I also added a dependent: destroy relationship in the equipment model between equipment and bookings so that when a piece of equipment is deleted so are all the related bookings

the equipment link in the navbar now redirects to the index too.